### PR TITLE
using half mse in examples for consistency

### DIFF
--- a/day00/ex08/ex08.md
+++ b/day00/ex08/ex08.md
@@ -24,12 +24,12 @@ Where:
 In the cost.py file, create the following function as per the instructions given below:
 ```python
 def cost_(y, y_hat):
-    """Computes the mean squared error of two non-empty numpy.ndarray, without any for loop. The two arrays must have the same dimensions.
+    """Computes the half mean squared error of two non-empty numpy.ndarray, without any for loop. The two arrays must have the same dimensions.
     Args:
       y: has to be an numpy.ndarray, a vector.
       y_hat: has to be an numpy.ndarray, a vector.
     Returns:
-      The mean squared error of the two vectors as a float.
+      The half mean squared error of the two vectors as a float.
       None if y or y_hat are empty numpy.ndarray.
       None if y and y_hat does not share the same dimensions.
     Raises:
@@ -46,7 +46,7 @@ Y = np.array([2, 14, -13, 5, 12, 4, -19])
 # Example 1:
 cost_(X, Y)
 # Output:
-4.285714285714286
+2.142857142857143
 
 # Example 2:
 cost_(X, X)


### PR DESCRIPTION
example/docstring were using mse instead of half mse as stated in the "Objective" section