### PR TITLE
typo (module04-ex08) module08 -> module03

### DIFF
--- a/module09/en.subject.tex
+++ b/module09/en.subject.tex
@@ -1071,7 +1071,7 @@ class MyLogisticRegression():
   \item \textbf{update} the \texttt{fit\_(self, x, y)} method: 
   \begin{itemize}
     \item \texttt{if penalty == 'l2'}: use a \textbf{regularized version} of the gradient descent.
-    \item \texttt{if penalty = 'none'}: use the \textbf{unregularized version} of the gradient descent from \texttt{module08}.
+    \item \texttt{if penalty = 'none'}: use the \textbf{unregularized version} of the gradient descent from \texttt{module03}.
   \end{itemize}
 \end{itemize}
 


### PR DESCRIPTION
Issue #166 

This is a easy review so I add @tflahaul.

Error of reference, the ml module 08 has became ml-module-03 so referencing it by module03 seems to be ok